### PR TITLE
Bug fixes & add `filename`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "gumlet/php-image-resize": "^1.9",
+        "gumlet/php-image-resize": "^2.0",
         "bramus/router": "~1.6"
     }
 }


### PR DESCRIPTION
- `webp` support: update gumlet/php-image-resize to `2.0.3` [example](https://www.gstatic.com/webp/gallery/1.webp)
- fix image `type/extension` contains `query string`
- add image filename
- minor bug fixes and improvements.